### PR TITLE
Add "Old Web" ASCII art logo to subnet calculator

### DIFF
--- a/subnet-calculator.html
+++ b/subnet-calculator.html
@@ -246,6 +246,29 @@
             font-size: 0.85rem;
         }
 
+        /* ASCII Logo */
+        .ascii-logo {
+            position: absolute;
+            top: 20px;
+            right: 40px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.65rem;
+            line-height: 1.1;
+            color: #4fc3f7;
+            text-shadow: 0 0 10px rgba(79, 195, 247, 0.3);
+            opacity: 0.8;
+            white-space: pre;
+        }
+
+        @media (max-width: 768px) {
+            .ascii-logo {
+                position: static;
+                text-align: center;
+                margin-bottom: 20px;
+                font-size: 0.5rem;
+            }
+        }
+
         /* Subnet List Styles */
         .subnet-list {
             display: none;
@@ -351,6 +374,12 @@
     </style>
 </head>
 <body>
+    <div class="ascii-logo">  ___  _    _  __        __   _
+ / _ \| | _| | \ \      / /__| |__
+| | | | |/ _` | \ \ /\ / / _ \ '_ \
+| |_| | | (_| |  \ V  V /  __/ |_) |
+ \___/|_|\__,_|   \_/\_/ \___|_.__/
+</div>
     <div class="container">
         <h1>Subnet Calculator</h1>
 


### PR DESCRIPTION
Added ASCII art logo in the upper right corner of the subnet calculator page that displays "Old Web" in a retro monospace style. The logo matches the existing color scheme and includes responsive styling for mobile devices.